### PR TITLE
feat: Add signed SSH cert script to remote into LLM VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
 # deploy-llm-bot
-Configuration-as-Code repo to deploy LLM Assist Bot
+Configuration-as-Code repo to deploy LLM Assist Bot.
+
+## Accessing the LLM VMs
+
+A combination of security measures is employed to secure access to the LLM Virtual Machines (VMs):
+
+- [Hashicorp Vault](https://www.hashicorp.com/products/vault): Signing SSH certificate at runtime, ensuring only our team members have access to the server. This certificate will expire after 8h.
+- [Github Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens): Validating that only members of the dev team can SSH into the VMs.
+- [Cloudflare Tunnel](https://github.com/cloudflare/cloudflared): The VMs do not have public IP addresses exposing to the internet, enhancing their security.
+
+As such, following the steps below to ensure you can access to the LLM VMs through a combination of secure tunnels, authenticated access, and signed certificates:
+
+### Install `cloudflared`
+
+Before proceeding, you must install `cloudflared` on your local machine. This tool creates a secure tunnel to the VMs, facilitating a secure connection without a public IP. For installation instructions, visit the [Cloudflare Tunnel documentation](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/).
+
+### Generate a GitHub Personal Access Token
+
+Next, create a GitHub personal access token with the `read:org` permission to log into Vault. Generate this token by visiting: https://github.com/settings/tokens/new?scopes=read:org.
+
+Safeguard this token as it will be used for authentication.
+
+### Update SSH Configuration
+
+Copy the host definition from the provided [ssh-config](ssh-config) file into your local `~/.ssh/config` to ensure your SSH client recognises how to connect to the VMs.
+
+### Option 1: Existing SSH Key on Private Computer
+
+If you're on a private computer and prefer using an `id_ed25519` key (recommended due to its security benefits over `id_rsa`, which is deprecated in recent Ubuntu LTS releases), follow these instructions to generate a new key pair:
+
+```bash
+ssh-keygen -t ed25519 -C "your_email@example.com"
+```
+
+Replace `"your_email@example.com"` with your email address. When prompted, you can specify a file in which to save the key, or preferably press Enter to use the default location.
+
+This key can then be reused for future authenticate with Vault. You will then need to sign your SSH public key and receive a signed SSH certificate:
+
+```bash
+./ssh-cert.sh issue ~/.ssh/id_ed25519.pub
+```
+
+You can then connect to the VM by using:
+
+```bash
+ssh bastion
+```
+
+### Option 2: Ephemeral SSH Key on Public Computer
+
+For users on a public computer, authenticate and generate an ephemeral SSH private key and certificateby running:
+
+```bash
+./ssh-cert.sh issue $name
+```
+
+This script produces an SSH certificate and private key. Connect to the VM using:
+
+```bash
+ssh -i $name-cert.pub -i $name bastion
+```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This key can then be reused for future authenticate with Vault. You will then ne
 You can then connect to the VM by using:
 
 ```bash
-ssh bastion
+ssh llm-bastion
 ```
 
 ### Option 2: Ephemeral SSH Key on Public Computer
@@ -58,5 +58,5 @@ For users on a public computer, authenticate and generate an ephemeral SSH priva
 This script produces an SSH certificate and private key. Connect to the VM using:
 
 ```bash
-ssh -i $name-cert.pub -i $name bastion
+ssh -i $name-cert.pub -i $name llm-bastion
 ```

--- a/ssh-cert.sh
+++ b/ssh-cert.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# This script is used to sign and issue SSH certificates for login into the llm-assistant VMs.
+#
+# The VMs are configured to use SSH certificates for login. Your public key must be signed by the
+# Vault SSH client signer to be able to login into the VMs.
+# If you don't have a public key, a new SSH certificate can be issued using the `issue` command.
+
+VAULT_API="https://vault.midgardlab.io/v1"
+TOKEN_FILE="$HOME/.config/vault/token"
+VAULT_ROLE="hyperstack-appadmin"
+
+# Usage example
+if [[ $# -lt 2 ]]; then
+    cat << EOF
+Usage: $0 [sign|issue] [ARGUMENTS]
+  sign [PATH_TO_PUBLIC_KEY]: Sign an existing SSH public key for login into the llm-assistant VMs.
+  issue [CERTIFICATE_NAME]: Issue a new SSH certificate for login into the llm-assistant VMs.
+EOF
+    exit 1
+fi
+
+# Login to Vault
+vault_login() {
+
+    if [[ ! -d "$HOME/.config/vault" ]]; then
+        mkdir -p "$HOME/.config/vault"
+    fi
+
+    read -p "Enter your GitHub personal token: " github_token
+
+    json="{ \"token\": \"$github_token\" }"
+
+    result=$(curl -s -X POST -d "$json" "$VAULT_API/auth/github/login")
+
+    if [[ $(echo "$result" | jq -r '.errors') == "null" ]]; then
+        client_token=$(echo "$result" | jq -r '.auth.client_token')
+
+        echo "$client_token" > "$TOKEN_FILE"
+        echo "Vault client token saved to $TOKEN_FILE"
+    else
+        echo "Error: Invalid GitHub personal token. Please try again."
+        vault_login
+    fi
+}
+
+# Check if the token file exists
+if [[ ! -f "$TOKEN_FILE" ]]; then
+    vault_login
+fi
+# Then load the Vault token
+VAULT_TOKEN=$(cat "$TOKEN_FILE")
+AUTH_HEADER="X-Vault-Token: $VAULT_TOKEN"
+
+# Issue a new SSH certificate
+issue_cert() {
+    certificate_name=$1
+    json="{ \"key_type\": \"ed25519\" }"
+
+    result=$(curl -s -X POST -H "$AUTH_HEADER" -d "$json" "$VAULT_API/ssh-client-signer/issue/$VAULT_ROLE")
+
+    if [[ $(echo "$result" | jq -r '.errors') == "null" ]]; then
+
+        private_key=$(echo "$result" | jq -r '.data.private_key')
+        signed_key=$(echo "$result" | jq -r '.data.signed_key')
+
+        echo "$private_key" > "$certificate_name"
+        echo "$signed_key" > "$certificate_name-cert.pub"
+
+        echo "Private key saved to $certificate_name"
+        echo "Public key saved to $certificate_name-cert.pub"
+
+    else
+        echo "Error: Authentication failed. Please login again."
+        vault_login
+        VAULT_TOKEN=$(cat "$TOKEN_FILE")
+        AUTH_HEADER="X-Vault-Token: $VAULT_TOKEN"
+        issue_cert "$certificate_name"
+    fi
+}
+
+# Sign an existing SSH public key
+sign_cert() {
+    public_key_file=$1
+    public_key=$(cat "$public_key_file")
+
+    cert_file="$(dirname $public_key_file)/$(basename -s .pub $public_key_file)-cert.pub"
+
+    json="{ \"public_key\": \"$public_key\" }"
+
+    result=$(curl -s -X POST -H "$AUTH_HEADER" -d "$json" "$VAULT_API/ssh-client-signer/sign/$VAULT_ROLE")
+
+    if [[ $(echo "$result" | jq -r '.errors') == "null" ]]; then
+        signed_key=$(echo "$result" | jq -r '.data.signed_key')
+
+        echo "$signed_key" > "$cert_file"
+        echo "Signed key saved to $cert_file"
+
+    else
+        echo "Error: Authentication failed. Please login again."
+        vault_login
+        VAULT_TOKEN=$(cat "$TOKEN_FILE")
+        AUTH_HEADER="X-Vault-Token: $VAULT_TOKEN"
+        sign_cert "$public_key_file"
+    fi
+}
+
+command=$1
+shift
+
+case $command in
+    # Sign an existing SSH public key
+    sign)
+        if [[ $# -lt 1 ]]; then
+            echo "Usage: $0 sign [PATH_TO_PUBLIC_KEY]"
+            exit 1
+        fi
+
+        sign_cert "$1"
+
+        ;;
+    # Issue a new SSH certificate along with a private key
+    issue)
+        if [[ $# -lt 1 ]]; then
+            echo "Usage: $0 issue [CERTIFICATE_NAME]"
+            exit 1
+        fi
+
+        issue_cert "$1"
+        ;;
+    *)
+        echo "Invalid command: $command"
+        exit 1
+        ;;
+esac

--- a/ssh-config
+++ b/ssh-config
@@ -1,0 +1,5 @@
+Host bastion
+   Hostname hyperstack.midgardlab.io
+   User deploy
+   ProxyCommand /usr/local/bin/cloudflared access ssh --hostname %h
+   ForwardAgent yes

--- a/ssh-config
+++ b/ssh-config
@@ -1,4 +1,4 @@
-Host bastion
+Host llm-bastion
    Hostname hyperstack.midgardlab.io
    User deploy
    ProxyCommand /usr/local/bin/cloudflared access ssh --hostname %h


### PR DESCRIPTION
This script and updated README provide instructions on how to SSH into our remote LLM VMs.

In particular, this implementation requires the use of Signed SSH certificate and Cloudflared. The reason why we do this is because:

1. Using signed SSH certificate reduces the Operational overhead of installing and managing SSH public keys on the VMs. Once your certificate is signed, you are allowed in.
2. The SSH certificate expires after 8h. There is no long running credential that can connect to the VMs directly, reducing the risks a leak private key comes back and bite us in the ass 6 months down the road.
3. Access is tied to Github team structure. Once a member leaves, their access is revoked.
4. Using cloudflared tunnel to reduces the amount of Chinese SSH bruteforce bots attacking the server and optimise the VM cost. We don't need to pay for a public IPv4, which cost around $USD7/month.