### PR TITLE
feat: Add cpu only ollama

### DIFF
--- a/bastion/docker-compose.yml
+++ b/bastion/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.9'
+services:
+  ollama:
+    image: ollama/ollama:0.1.27
+    restart: unless-stopped
+    networks:
+      - bridge
+    ports:
+      - 11434:11434
+    volumes:
+      - /opt/models:/root/.ollama
+
+networks:
+  bridge:
+    name: bridge_network
+    external: true


### PR DESCRIPTION
This PR introduces a CPU only Ollama instance that is designed to run with the following lightweight models for quick API testing and development:

- phi
- gemma:2b

